### PR TITLE
add axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ts-node": "ts-node"
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "oauth-1.0a": "^2.2.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1147,6 +1147,13 @@ axios@0.21.0:
   dependencies:
     follow-redirects "^1.10.0"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"


### PR DESCRIPTION
This PR adds `axios` to the dependency.
Without it, axios will not be installed when imported as a library and the developer will encounter the following error: ` Error: Cannot find module 'axios' `